### PR TITLE
Explicitly set SHELL to cmd.exe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL = cmd.exe
 CC = gcc
 CFLAGS = -std=c17 -Wall -Wextra -Wpedantic -O2 -g
 SRCDIR = src


### PR DESCRIPTION
The Makefile relies specifically on cmd.exe. GNU Make prefers a unix shell if available. It will look for one and use it unless told to use a specific shell such as cmd.exe.